### PR TITLE
gateware/ci: add windows builds to CI and README

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: YosysHQ/setup-oss-cad-suite@v1
+      - uses: YosysHQ/setup-oss-cad-suite@v2
       - run: git submodule update --init gateware/external/no2misc
       - run: yosys --version
       - run: make BOARD=icebreaker CORE=mirror -C gateware
+      - uses: actions/upload-artifact@v3
+        with:
+          name: icebreaker.bin
+          path: gateware/build/icebreaker/top.bin
+
+  windows-build-icebreaker:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          install: >-
+            git
+            make
+      - uses: actions/checkout@v3
+      - uses: YosysHQ/setup-oss-cad-suite@v2
+      - run: git submodule update --init gateware/external/no2misc
+      - run: |
+          export PATH=$PATH:/d/a/_temp/oss-cad-suite/bin
+          export PATH=$PATH:/d/a/_temp/oss-cad-suite/lib
+          yosys --version
+          make BOARD=icebreaker CORE=mirror -C gateware
       - uses: actions/upload-artifact@v3
         with:
           name: icebreaker.bin
@@ -20,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: YosysHQ/setup-oss-cad-suite@v1
+      - uses: YosysHQ/setup-oss-cad-suite@v2
       - run: git submodule update --init gateware/external/no2misc
       - run: yosys --version
       - run: make BOARD=colorlight_i5 CORE=mirror -C gateware
@@ -29,11 +53,11 @@ jobs:
           name: colorlight-i5.bin
           path: gateware/build/colorlight_i5/top.bin
 
-  ubuntu-colorlight-i9:
+  ubuntu-build-colorlight-i9:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: YosysHQ/setup-oss-cad-suite@v1
+      - uses: YosysHQ/setup-oss-cad-suite@v2
       - run: git submodule update --init gateware/external/no2misc
       - run: yosys --version
       - run: make BOARD=colorlight_i9 CORE=mirror -C gateware
@@ -46,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: YosysHQ/setup-oss-cad-suite@v1
+      - uses: YosysHQ/setup-oss-cad-suite@v2
       - run: git submodule update --init gateware/external/no2misc
       - run: cocotb-config -v
       - run: cd gateware/sim && ./00_run.sh
@@ -55,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: YosysHQ/setup-oss-cad-suite@v1
+      - uses: YosysHQ/setup-oss-cad-suite@v2
       - run: git submodule update --init gateware/external/no2misc
       - run: verilator --version
       - run: cd gateware && scripts/verilator_lint.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - run: make BOARD=icebreaker CORE=mirror -C gateware
       - uses: actions/upload-artifact@v3
         with:
-          name: icebreaker.bin
+          name: ubuntu-build-icebreaker.bin
           path: gateware/build/icebreaker/top.bin
 
   windows-build-icebreaker:
@@ -31,13 +31,13 @@ jobs:
       - uses: YosysHQ/setup-oss-cad-suite@v2
       - run: git submodule update --init gateware/external/no2misc
       - run: |
-          export PATH=$PATH:/d/a/_temp/oss-cad-suite/bin
-          export PATH=$PATH:/d/a/_temp/oss-cad-suite/lib
+          export PATH=$PATH:$RUNNER_TEMP/oss-cad-suite/bin
+          export PATH=$PATH:$RUNNER_TEMP/oss-cad-suite/lib
           yosys --version
           make BOARD=icebreaker CORE=mirror -C gateware
       - uses: actions/upload-artifact@v3
         with:
-          name: icebreaker.bin
+          name: windows-build-icebreaker.bin
           path: gateware/build/icebreaker/top.bin
 
   ubuntu-build-colorlight-i5:
@@ -50,7 +50,7 @@ jobs:
       - run: make BOARD=colorlight_i5 CORE=mirror -C gateware
       - uses: actions/upload-artifact@v3
         with:
-          name: colorlight-i5.bin
+          name: ubuntu-build-colorlight-i5.bin
           path: gateware/build/colorlight_i5/top.bin
 
   ubuntu-build-colorlight-i9:
@@ -63,7 +63,7 @@ jobs:
       - run: make BOARD=colorlight_i9 CORE=mirror -C gateware
       - uses: actions/upload-artifact@v3
         with:
-          name: colorlight-i9.bin
+          name: ubuntu-build-colorlight-i9.bin
           path: gateware/build/colorlight_i9/top.bin
 
   run-tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,44 +3,44 @@ name: build & test
 on: [push, pull_request]
 
 jobs:
-  build-bitstream-icebreaker:
+  ubuntu-build-icebreaker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: YosysHQ/setup-oss-cad-suite@v1
       - run: git submodule update --init gateware/external/no2misc
       - run: yosys --version
-      - run: make BOARD=icebreaker -C gateware
+      - run: make BOARD=icebreaker CORE=mirror -C gateware
       - uses: actions/upload-artifact@v3
         with:
-          name: eurorack-pmod-bitstream.bin
-          path: gateware/top.bin
+          name: icebreaker.bin
+          path: gateware/build/icebreaker/top.bin
 
-  build-bitstream-colorlight-i5:
+  ubuntu-build-colorlight-i5:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: YosysHQ/setup-oss-cad-suite@v1
       - run: git submodule update --init gateware/external/no2misc
       - run: yosys --version
-      - run: make BOARD=colorlight_i5 -C gateware
+      - run: make BOARD=colorlight_i5 CORE=mirror -C gateware
       - uses: actions/upload-artifact@v3
         with:
-          name: eurorack-pmod-bitstream.bin
-          path: gateware/top.bin
+          name: colorlight-i5.bin
+          path: gateware/build/colorlight_i5/top.bin
 
-  build-bitstream-colorlight-i9:
+  ubuntu-colorlight-i9:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: YosysHQ/setup-oss-cad-suite@v1
       - run: git submodule update --init gateware/external/no2misc
       - run: yosys --version
-      - run: make BOARD=colorlight_i9 -C gateware
+      - run: make BOARD=colorlight_i9 CORE=mirror -C gateware
       - uses: actions/upload-artifact@v3
         with:
-          name: eurorack-pmod-bitstream.bin
-          path: gateware/top.bin
+          name: colorlight-i9.bin
+          path: gateware/build/colorlight_i9/top.bin
 
   run-tests:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This repository contains a bunch of example DSP cores which are continuously bei
 - VCA (voltage controlled amplifier)
 - VCO (voltage controlled oscillator)
 
-These examples can all run out of the box on the development boards listed below. The repository currently only supports a Linux-based development environment, however porting to Mac / Windows should be fairly trivial and maybe the community can do it :).
+These examples can all run out of the box on the development boards listed below.
 
 ## Choosing an FPGA development board
 An FPGA development board itself is NOT included! Essentially anything iCE40 or ECP5 based that has a PMOD connector will support the open-source tools and the examples in this project. Just make sure you have enough LUTS, >3K is enough to do interesting things.
@@ -62,9 +62,16 @@ The following development boards have been tested with `eurorack-pmod` and are s
 
 ## Getting Started
 
-0. Install the OSS FPGA CAD flow. The gateware is automatically built and tested in CI, so it may be helpful to look at [`.github/workflows/main.yml`](.github/workflows/main.yml).
-1. Build or obtain `eurorack-pmod` hardware and connect it to your FPGA development board using a ribbon cable or similar. (Double check that the pin mappings are correct, some ribbon cables will swap them on you)
-2. Try some of the examples. From the `gateware` directory, type `make` to see valid commands. By default it will compile a bitstream with the 'mirror' core, which just sends inputs to outputs.
+For now, I have tested builds on Linux and Windows (under MSYS2). Both are tested in CI.
+
+0. Install the [OSS FPGA CAD flow](https://github.com/yosyshq/oss-cad-suite-build).
+    - You may be able to get yosys / verilator from other package managers but I recommend using the [releases from YosysHQ](https://github.com/yosyshq/oss-cad-suite-build) so you're using the same binaries that CI is using.
+    - On Linux, once the YosysHQ suite is installed and in PATH, you should be able to just use `make` in the gateware directory.
+    - On Windows, CI is using MSYS2 with MINGW64 shell. Install MSYS2, MINGW64, extract the oss-cad-suite from YosysHQ and add it to PATH. Then you should be able to use `make` in the gateware directory.
+    - Note: The gateware is automatically built and tested in CI, so for either platform it may be helpful to look at [`.github/workflows/main.yml`](.github/workflows/main.yml).
+
+1. Build or obtain `eurorack-pmod` hardware and connect it to your FPGA development board using a ribbon cable or similar. (Double check that the pin mappings are correct, some ribbon cables will swap them on you! Default pinmaps are for the ribbon cables I shipped with hardware, you need to flip the pinmaps for a direct connection PMOD -> FPGA)
+2. Try some of the examples. From the `gateware` directory, type `make` to see valid commands. By default if you do not select a CORE it will compile a bitstream with the 'mirror' core, which just sends inputs to outputs.
 2. Calibrate your hardware using the process described in [`gateware/cal/cal.py`](gateware/cal/cal.py). Use this to create your own `gateware/cal/cal_mem.hex` to compensate for any DC biases in the ADCs/DACs. (this step is only necessary if you need sub-50mV accuracy on your inputs/outputs, which is the case if you are tuning oscillators, not so much if you are creating rhythm pulses.
 
 # Project structure

--- a/gateware/cal/cal.sv
+++ b/gateware/cal/cal.sv
@@ -18,7 +18,7 @@
 
 module cal #(
     parameter W = 16, // sample width
-    parameter CAL_MEM_FILE = "cal_mem.hex"
+    parameter CAL_MEM_FILE = "cal/cal_mem.hex"
 )(
     input clk, // 12Mhz
     input sample_clk,

--- a/gateware/cores/sampler.sv
+++ b/gateware/cores/sampler.sv
@@ -14,7 +14,7 @@ module sampler #(
     parameter W = 16,
     parameter FP_OFFSET = 2,
     parameter N_SAMPLES = 12'h690,
-    parameter PATH_SAMPLES = "util/sampler_data/clap.hex"
+    parameter PATH_SAMPLES = "cores/util/sampler_data/clap.hex"
 )(
     input clk,
     input sample_clk,

--- a/gateware/cores/vco.sv
+++ b/gateware/cores/vco.sv
@@ -6,9 +6,9 @@
 
 module vco #(
     parameter W = 16,
-    parameter V_OCT_LUT_PATH = "util/vco/v_oct_lut.hex",
+    parameter V_OCT_LUT_PATH = "cores/util/vco/v_oct_lut.hex",
     parameter V_OCT_LUT_SIZE = 512,
-    parameter WAVETABLE_PATH = "util/vco/wavetable.hex",
+    parameter WAVETABLE_PATH = "cores/util/vco/wavetable.hex",
     parameter WAVETABLE_SIZE = 256,
     parameter FDIV = 0 // Divide output frequency by 1 << FDIV.
                        // Useful if you want to use this as an LFO.

--- a/gateware/drivers/pmod_i2c_master.sv
+++ b/gateware/drivers/pmod_i2c_master.sv
@@ -13,9 +13,9 @@
 `default_nettype none
 
 module pmod_i2c_master #(
-    parameter CODEC_CFG  = "ak4619-cfg.hex",
+    parameter CODEC_CFG  = "drivers/ak4619-cfg.hex",
     parameter CODEC_CFG_BYTES = 16'd23,
-    parameter LED_CFG  = "pca9635-cfg.hex",
+    parameter LED_CFG  = "drivers/pca9635-cfg.hex",
     parameter LED_CFG_BYTES = 16'd26
 )(
     input  clk,

--- a/gateware/eurorack_pmod.sv
+++ b/gateware/eurorack_pmod.sv
@@ -9,7 +9,7 @@
 
 module eurorack_pmod #(
     parameter W = 16, // sample width, bits
-    parameter CAL_MEM_FILE = "cal_mem.hex"
+    parameter CAL_MEM_FILE = "cal/cal_mem.hex"
 )(
     input clk_12mhz,   // Assumed 12MHz
     input rst,

--- a/gateware/sim/cal/cal/cal_mem.hex
+++ b/gateware/sim/cal/cal/cal_mem.hex
@@ -1,0 +1,1 @@
+../../../cal/cal_mem.hex

--- a/gateware/sim/cal/cal_mem.hex
+++ b/gateware/sim/cal/cal_mem.hex
@@ -1,1 +1,0 @@
-../../cal/cal_mem.hex

--- a/gateware/sim/cal/tb_cal.py
+++ b/gateware/sim/cal/tb_cal.py
@@ -34,7 +34,7 @@ async def test_cal_00(dut):
     ]
 
     cal_mem = []
-    with open("cal_mem.hex", "r") as f_cal_mem:
+    with open("cal/cal_mem.hex", "r") as f_cal_mem:
         for line in f_cal_mem.readlines():
             if '//' in line:
                 continue

--- a/gateware/sim/pmod_i2c_master/ak4619-cfg.hex
+++ b/gateware/sim/pmod_i2c_master/ak4619-cfg.hex
@@ -1,1 +1,0 @@
-../../drivers/ak4619-cfg.hex

--- a/gateware/sim/pmod_i2c_master/drivers/ak4619-cfg.hex
+++ b/gateware/sim/pmod_i2c_master/drivers/ak4619-cfg.hex
@@ -1,0 +1,1 @@
+../../../drivers/ak4619-cfg.hex

--- a/gateware/sim/pmod_i2c_master/pca9635-cfg.hex
+++ b/gateware/sim/pmod_i2c_master/pca9635-cfg.hex
@@ -1,1 +1,0 @@
-../../drivers/pca9635-cfg.hex


### PR DESCRIPTION
- Also switch to absolute paths for .hex file searches given this seems to be necessary on Windows. Not ideal but after a quick search there does not seem to be a simple alternative.