### PR TITLE
boards/pico-ice: add support for tinyvision pico-ice-r3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,19 @@ jobs:
           name: ubuntu-build-colorlight-i9.bin
           path: gateware/build/colorlight_i9/top.bin
 
+  ubuntu-build-pico-ice:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: YosysHQ/setup-oss-cad-suite@v2
+      - run: git submodule update --init gateware/external/no2misc
+      - run: yosys --version
+      - run: make BOARD=pico_ice CORE=mirror -C gateware
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ubuntu-build-pico-ice.bin
+          path: gateware/build/pico_ice/top.bin
+
   run-tests:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For a high-level overview on R2.2 hardware, **see [my FOSDEM '23 talk](https://y
 
 ### This project is:
 - The design for a Eurorack-compatible PCB and front-panel, including a [PMOD](https://en.wikipedia.org/wiki/Pmod_Interface) connector (compatible with most FPGA dev boards). PCB designed in [KiCAD](https://www.kicad.org/). Design is [certified open hardware](https://certification.oshwa.org/de000135.html).
-- Various [example cores](gateware/cores) (and calibration / driver cores for the audio CODEC) initially targeting an [iCEBreaker FPGA](https://1bitsquared.com/products/icebreaker) (iCE40 part) and Colorlight i5 / i9 (ECP5 part). Examples include calibration, sampling, effects, synthesis sources and so on. The design files can be synthesized to a bitstream using Yosys' [oss-cad-suite](https://github.com/YosysHQ/oss-cad-suite-build).
+- Various [example cores](gateware/cores) (and calibration / driver cores for the audio CODEC) initially targeting an [iCEBreaker FPGA](https://1bitsquared.com/products/icebreaker) (iCE40 part) but many more boards are supported (see below). Examples include calibration, sampling, effects, synthesis sources and so on. The design files can be synthesized to a bitstream using Yosys' [oss-cad-suite](https://github.com/YosysHQ/oss-cad-suite-build).
 - A [VCV Rack plugin](https://github.com/schnommus/verilog-vcvrack) so you can simulate your Verilog designs in a completely virtual modular system, no hardware required.
 
 ## Included examples
@@ -41,6 +41,7 @@ The following development boards have been tested with `eurorack-pmod` and are s
 - iCEbreaker (iCE40 based)
 - Colorlight i5 (ECP5 based)
 - Colorlight i9 (ECP5 based)
+- pico-ice from TinyVision (iCE40 based)
 
 ## Hardware details
 
@@ -57,7 +58,7 @@ The following development boards have been tested with `eurorack-pmod` and are s
 - I/O is about +/- 8V capable, wider is possible with a resistor change.
 
 ## Gateware details
-- Examples based on Icebreaker (iCE40 part) / Colorlight i5 / i9 (ECP5 part).
+- Examples based on iCE40 and ECP5 based FPGAs supported by open-source tools.
 - User-defined DSP logic is decoupled from rest of system (see [`gateware/cores`](gateware/cores) directory)
 
 ## Getting Started

--- a/gateware/boards/pico_ice/Makefile
+++ b/gateware/boards/pico_ice/Makefile
@@ -1,0 +1,12 @@
+PROJ = top
+
+DEVICE = up5k
+PACKAGE = sg48
+PIN_DEF = ./boards/pico_ice/pinmap.pcf
+ADD_DEFINES = -DSELECTED_DSP_CORE=$(CORE) -DINVERT_BUTTON=1 -DINTERNAL_CLOCK=1
+
+include ./mk/common.mk
+include ./mk/ice40.mk
+
+ADD_SRC = boards/pico_ice/sysmgr.v \
+		  $(SRC_COMMON)

--- a/gateware/boards/pico_ice/README.md
+++ b/gateware/boards/pico_ice/README.md
@@ -1,0 +1,14 @@
+# Support for `pico-ice` from `tinyvision-ai-inc`
+
+At the moment this uses the internal HFOSC at 12MHz so we don't depend on the RP2040 sending a clock signal to the FPGA.
+
+Assuming the RP2040 is programmed with the DFU bootloader you can flash the binary over DFU with something like:
+
+```
+$ make BOARD=pico_ice
+$ sudo dfu-util --alt 0 -D build/pico_ice/top.bin
+```
+
+I have removed the prog target for this board as there are a few different ways of flashing the FPGA depending on how the RP2040 is programmed.
+
+I have not tried to mirror the UART through the RP2040 yet but it should be reasonable to do so by copying one of the pico-ice examples.

--- a/gateware/boards/pico_ice/pinmap.pcf
+++ b/gateware/boards/pico_ice/pinmap.pcf
@@ -1,0 +1,17 @@
+# No clock. using internal HFOSC
+
+# NOTE: this UART needs to be forwarded by the RP2040 FW!
+set_io -nowarn UART_TX           26
+# Reset button is pressed == low so we need to invert it.
+set_io -nowarn RESET_BUTTON      10
+
+# ICE_PMOD_1 (closest USB), assuming horizontal flip (ribbon cable
+# between eurorack-pmod and PMOD connector IS in place).
+set_io -nowarn PMOD_SDIN1     4
+set_io -nowarn PMOD_SDOUT1    2
+set_io -nowarn PMOD_LRCK      47
+set_io -nowarn PMOD_BICK      45
+set_io -nowarn PMOD_I2C_SCL   3
+set_io -nowarn PMOD_I2C_SDA   48
+set_io -nowarn PMOD_PDN       46
+set_io -nowarn PMOD_MCLK      44

--- a/gateware/boards/pico_ice/sysmgr.v
+++ b/gateware/boards/pico_ice/sysmgr.v
@@ -1,0 +1,40 @@
+`default_nettype none
+
+module sysmgr (
+	input  wire rst_in,
+	output wire clk_12m,
+	output wire rst_out
+);
+
+    wire clk_12m;
+	wire rst_i;
+	reg [7:0] rst_cnt = 8'h80;
+
+`ifndef VERILATOR_LINT_ONLY
+	// The Pico-Ice V3 examples seem to use the internal ICE40 HFOSC
+    SB_HFOSC #(
+        .CLKHF_DIV("0b10") // /4 == 12MHz
+    ) internal_osc (
+        .CLKHFEN(1'b1),
+        .CLKHFPU(1'b1),
+        .CLKHF(clk_12m)
+    );
+`endif
+
+	// Logic reset generation
+	always @(posedge clk_12m or posedge rst_in)
+		if (rst_in)
+			rst_cnt <= 8'h80;
+		else if (rst_cnt[7])
+			rst_cnt <= rst_cnt + 1;
+
+	assign rst_i = rst_cnt[7];
+
+`ifndef VERILATOR_LINT_ONLY
+	SB_GB rst_gbuf_I (
+		.USER_SIGNAL_TO_GLOBAL_BUFFER(rst_i),
+		.GLOBAL_BUFFER_OUTPUT(rst_out)
+	);
+`endif
+
+endmodule // sysmgr

--- a/gateware/top.sv
+++ b/gateware/top.sv
@@ -9,20 +9,22 @@
 module top #(
     parameter int W = 16 // sample width, bits
 )(
-     input   CLK
-    ,inout   PMOD_I2C_SDA
-    ,inout   PMOD_I2C_SCL
-    ,output  PMOD_LRCK
-    ,output  PMOD_BICK
-    ,output  PMOD_SDIN1
-    ,input   PMOD_SDOUT1
-    ,output  PMOD_PDN
-    ,output  PMOD_MCLK
+`ifndef INTERNAL_CLOCK
+    input   CLK,
+`endif
+    inout   PMOD_I2C_SDA,
+    inout   PMOD_I2C_SCL,
+    output  PMOD_LRCK,
+    output  PMOD_BICK,
+    output  PMOD_SDIN1,
+    input   PMOD_SDOUT1,
+    output  PMOD_PDN,
+    output  PMOD_MCLK,
     // Button used for reset and output cal. Assumed momentary, pressed == HIGH.
     // You can use any random PMOD that has a button on it.
-    ,input   RESET_BUTTON
+    input   RESET_BUTTON,
     // UART used for debug information and for calibration.
-    ,output  UART_TX
+    output  UART_TX
 );
 
 logic rst;
@@ -67,8 +69,11 @@ logic signed [W-1:0] debug_adc3;
 
 // PLL bringup and reset state management / debouncing.
 sysmgr sysmgr_instance (
-    // The input clock frequency might be different for different boards.
+`ifndef INTERNAL_CLOCK
+    // Warning: the input clock frequency might be different for different boards.
+    // Make sure to adjust sysmgr / PLLs for your board as such.
     .clk_in(CLK),
+`endif
 `ifndef OUTPUT_CALIBRATION
     // Normally, the uButton is used as a global reset button.
     .rst_in(button),


### PR DESCRIPTION
- Add basic support for the pico-ice board (RP2040 + ICE40). This one is a bit different to other boards as we use the ICE40's internal HFOSC.
- I haven't tested UART mirroring through the RP2040 yet, but the gateware examples all seem to work fine on downloading them through DFU.