### PR TITLE
sim/integration: add top-level simulation [icebreaker]

### DIFF
--- a/gateware/boards/icebreaker/sysmgr.v
+++ b/gateware/boards/icebreaker/sysmgr.v
@@ -30,6 +30,7 @@ module sysmgr (
 	assign clk_fs = clkdiv[7];
 
 	// PLL instance
+`ifndef COCOTB_SIM
 `ifndef VERILATOR_LINT_ONLY
 	SB_PLL40_2F_PAD #(
 		.DIVR(4'b0000),
@@ -57,6 +58,9 @@ module sysmgr (
 		.SCLK(1'b0)
 	);
 `endif
+`else
+    assign clk_1x_i = clk_in;
+`endif
 
 	// Logic reset generation
 	always @(posedge clk_1x_i or negedge pll_lock)
@@ -72,11 +76,15 @@ module sysmgr (
             clkdiv <= clkdiv + 1;
 
 
+`ifndef COCOTB_SIM
 `ifndef VERILATOR_LINT_ONLY
 	SB_GB rst_gbuf_I (
 		.USER_SIGNAL_TO_GLOBAL_BUFFER(rst_i),
 		.GLOBAL_BUFFER_OUTPUT(rst_out)
 	);
+`endif
+`else
+    assign rst_out = rst_i;
 `endif
 
 endmodule // sysmgr

--- a/gateware/cal/cal.sv
+++ b/gateware/cal/cal.sv
@@ -124,10 +124,10 @@ always_ff @(posedge clk_256fs) begin
             end
             CAL_ST_OUT: begin
                 // Calibrated input samples are zeroed if jack disconnected.
-                out0  <= out[0][W-1:0];
-                out1  <= out[1][W-1:0];
-                out2  <= out[2][W-1:0];
-                out3  <= out[3][W-1:0];
+                out0  <= jack[0] ? out[0][W-1:0] : 0;
+                out1  <= jack[1] ? out[1][W-1:0] : 0;
+                out2  <= jack[2] ? out[2][W-1:0] : 0;
+                out3  <= jack[3] ? out[3][W-1:0] : 0;
                 out4  <= out[4][W-1:0];
                 out5  <= out[5][W-1:0];
                 out6  <= out[6][W-1:0];
@@ -142,11 +142,21 @@ always_ff @(posedge clk_256fs) begin
 end
 
 `ifdef COCOTB_SIM
+
+`ifdef UNIT_TEST
+initial begin
+  $dumpfile ("cal.vcd");
+  $dumpvars;
+  #1;
+end
+`endif
+
+// Shadow fake wires so we can look inside verilog arrays in vcd trace.
 generate
   genvar idx;
   for(idx = 0; idx < 8; idx = idx+1) begin: register
-    wire [31:0] tmp;
-    assign tmp = out[idx];
+    wire [31:0] out_dummy;
+    assign out_dummy = out[idx];
   end
 endgenerate
 `endif

--- a/gateware/drivers/ak4619.sv
+++ b/gateware/drivers/ak4619.sv
@@ -123,4 +123,24 @@ always_ff @(posedge clk_256fs) begin
 end
 
 
+`ifdef COCOTB_SIM
+`ifdef UNIT_TEST
+initial begin
+  $dumpfile ("ak4619.vcd");
+  $dumpvars;
+  #1;
+end
+`endif
+
+// Shadow fake wires so we can look inside verilog arrays in vcd trace.
+generate
+  genvar idx;
+  for(idx = 0; idx < N_CHANNELS; idx = idx+1) begin: register
+    wire [W-1:0] adc_dummy;
+    assign adc_dummy = adc_words[idx];
+  end
+endgenerate
+
+`endif
+
 endmodule

--- a/gateware/drivers/ak4619.sv
+++ b/gateware/drivers/ak4619.sv
@@ -96,9 +96,6 @@ always_ff @(posedge clk_256fs) begin
         // BICK transition HI -> LO: Clock in W bits
         // On HI -> LO both SDIN and SDOUT do not transition.
         // (determined by AK4619 transition polarity register BCKP)
-        if (bit_counter == 0) begin
-            adc_words[channel] <= 0;
-        end
         if (bit_counter < W) begin
             adc_words[channel][W - bit_counter - 1] <= sdout1;
         end

--- a/gateware/drivers/ak4619.sv
+++ b/gateware/drivers/ak4619.sv
@@ -122,12 +122,5 @@ always_ff @(posedge clk_256fs) begin
     end
 end
 
-`ifdef COCOTB_SIM
-initial begin
-  $dumpfile ("ak4619.vcd");
-  $dumpvars;
-  #1;
-end
-`endif
 
 endmodule

--- a/gateware/drivers/pmod_i2c_master.sv
+++ b/gateware/drivers/pmod_i2c_master.sv
@@ -63,6 +63,11 @@ localparam I2C_DELAY1        = 0,
            I2C_JACK2         = 8, // >>--/
            I2C_IDLE          = 9;
 
+`ifdef COCOTB_SIM
+localparam STARTUP_DELAY_BIT = 4;
+`else
+localparam STARTUP_DELAY_BIT = 17;
+`endif
 
 logic [3:0] i2c_state = I2C_DELAY1;
 
@@ -109,7 +114,7 @@ always_ff @(posedge clk) begin
         if (ready && ~stb) begin
             case (i2c_state)
                 I2C_DELAY1: begin
-                    if(delay_cnt[17])
+                    if(delay_cnt[STARTUP_DELAY_BIT])
                         i2c_state <= I2C_EEPROM1;
                 end
                 I2C_EEPROM1: begin
@@ -296,13 +301,5 @@ i2c_master #(.DW(4)) i2c_master_inst(
     .clk(clk),
     .rst(rst)
 );
-
-`ifdef COCOTB_SIM
-initial begin
-  $dumpfile ("pmod_i2c_master.vcd");
-  $dumpvars;
-  #1;
-end
-`endif
 
 endmodule

--- a/gateware/drivers/pmod_i2c_master.sv
+++ b/gateware/drivers/pmod_i2c_master.sv
@@ -302,4 +302,14 @@ i2c_master #(.DW(4)) i2c_master_inst(
     .rst(rst)
 );
 
+`ifdef COCOTB_SIM
+`ifdef UNIT_TEST
+initial begin
+  $dumpfile ("pmod_i2c_master.vcd");
+  $dumpvars;
+  #1;
+end
+`endif
+`endif
+
 endmodule

--- a/gateware/eurorack_pmod.sv
+++ b/gateware/eurorack_pmod.sv
@@ -76,6 +76,7 @@ cal #(
     .W(W),
     .CAL_MEM_FILE(CAL_MEM_FILE)
 )cal_instance (
+    .rst(rst),
     .clk_256fs (clk_256fs),
     .clk_fs (clk_fs),
     // Calibrated inputs are zeroed if jack is unplugged.
@@ -117,11 +118,12 @@ ak4619 ak4619_instance (
     .sample_out1 (sample_adc1),
     .sample_out2 (sample_adc2),
     .sample_out3 (sample_adc3),
-    .sample_in0 (force_dac_output == 0 ? sample_dac0 : force_dac_output),
-    .sample_in1 (force_dac_output == 0 ? sample_dac1 : force_dac_output),
-    .sample_in2 (force_dac_output == 0 ? sample_dac2 : force_dac_output),
-    .sample_in3 (force_dac_output == 0 ? sample_dac3 : force_dac_output)
+    .sample_in0 (sample_dac0),
+    .sample_in1 (sample_dac1),
+    .sample_in2 (sample_dac2),
+    .sample_in3 (sample_dac3)
 );
+
 
 // I2C transceiver and driver for all connected slaves.
 pmod_i2c_master #(

--- a/gateware/eurorack_pmod.sv
+++ b/gateware/eurorack_pmod.sv
@@ -118,10 +118,10 @@ ak4619 ak4619_instance (
     .sample_out1 (sample_adc1),
     .sample_out2 (sample_adc2),
     .sample_out3 (sample_adc3),
-    .sample_in0 (sample_dac0),
-    .sample_in1 (sample_dac1),
-    .sample_in2 (sample_dac2),
-    .sample_in3 (sample_dac3)
+    .sample_in0 (force_dac_output == 0 ? sample_dac0 : force_dac_output),
+    .sample_in1 (force_dac_output == 0 ? sample_dac1 : force_dac_output),
+    .sample_in2 (force_dac_output == 0 ? sample_dac2 : force_dac_output),
+    .sample_in3 (force_dac_output == 0 ? sample_dac3 : force_dac_output)
 );
 
 

--- a/gateware/sim/ak4619/Makefile
+++ b/gateware/sim/ak4619/Makefile
@@ -2,5 +2,6 @@ SIM ?= icarus
 TOPLEVEL_LANG ?= verilog
 VERILOG_SOURCES = ../../drivers/ak4619.sv
 MODULE = tb_ak4619
+COMPILE_ARGS += -DUNIT_TEST
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/gateware/sim/cal/Makefile
+++ b/gateware/sim/cal/Makefile
@@ -2,5 +2,6 @@ SIM ?= icarus
 TOPLEVEL_LANG ?= verilog
 VERILOG_SOURCES = ../../cal/cal.sv
 MODULE = tb_cal
+COMPILE_ARGS += -DUNIT_TEST
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/gateware/sim/cal/tb_cal.py
+++ b/gateware/sim/cal/tb_cal.py
@@ -46,18 +46,23 @@ async def test_cal_00(dut):
 
 
     channel = 0
-    for cal_inx, cal_outx in [(dut.in0, dut.out0),
-                              (dut.in1, dut.out1),
-                              (dut.in2, dut.out2),
-                              (dut.in3, dut.out3),
-                              (dut.in4, dut.out4),
-                              (dut.in5, dut.out5),
-                              (dut.in6, dut.out6),
-                              (dut.in7, dut.out7)]:
+    all_ins_outs = [(dut.in0, dut.out0),
+                    (dut.in1, dut.out1),
+                    (dut.in2, dut.out2),
+                    (dut.in3, dut.out3),
+                    (dut.in4, dut.out4),
+                    (dut.in5, dut.out5),
+                    (dut.in6, dut.out6),
+                    (dut.in7, dut.out7)]
+    for cal_inx, cal_outx in all_ins_outs:
 
         for value in test_values:
             expect = ((value - cal_mem[channel*2]) *
                       cal_mem[channel*2 + 1]) >> 10
+            # Default all inputs to zero so we don't have undefined
+            # values everywhere else in the input array.
+            for i, o in all_ins_outs:
+                i.value = Force(0)
             cal_inx.value = Force(signed_to_twos_comp(value))
             if expect >  32000: expect = 32000
             if expect < -32000: expect = -32000

--- a/gateware/sim/integration/Makefile
+++ b/gateware/sim/integration/Makefile
@@ -1,0 +1,18 @@
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+TOPLEVEL = top
+VERILOG_SOURCES = ../../top.sv \
+				  ../../eurorack_pmod.sv \
+				  ../../drivers/ak4619.sv \
+				  ../../cal/cal.sv \
+				  ../../boards/icebreaker/sysmgr.v \
+				  ../../drivers/pmod_i2c_master.sv \
+				  ../../external/no2misc/rtl/i2c_master.v \
+				  ../../cal/debug_uart.sv \
+				  ../../external/no2misc/rtl/uart_tx.v \
+				  ../../cores/mirror.sv
+
+MODULE = tb_integration
+COMPILE_ARGS += -DSELECTED_DSP_CORE=mirror
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/gateware/sim/integration/cal/cal_mem.hex
+++ b/gateware/sim/integration/cal/cal_mem.hex
@@ -1,0 +1,1 @@
+../../../cal/cal_mem.hex

--- a/gateware/sim/integration/drivers/ak4619-cfg.hex
+++ b/gateware/sim/integration/drivers/ak4619-cfg.hex
@@ -1,0 +1,1 @@
+../../../drivers/ak4619-cfg.hex

--- a/gateware/sim/integration/drivers/pca9635-cfg.hex
+++ b/gateware/sim/integration/drivers/pca9635-cfg.hex
@@ -1,0 +1,1 @@
+../../../drivers/pca9635-cfg.hex

--- a/gateware/sim/integration/tb_integration.py
+++ b/gateware/sim/integration/tb_integration.py
@@ -1,0 +1,62 @@
+import math
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import Timer, FallingEdge, RisingEdge, ClockCycles
+from cocotb.handle import Force, Release
+
+
+async def clock_out_word(dut, word):
+    await FallingEdge(dut.bick)
+    for i in range(32):
+        await RisingEdge(dut.bick)
+        dut.sdout1.value = (word >> (0x1F-i)) & 1
+
+async def clock_in_word(dut):
+    word = 0x00000000
+    await RisingEdge(dut.bick)
+    for i in range(32):
+        await FallingEdge(dut.bick)
+        word |= dut.sdin1.value << (0x1F-i)
+    return word
+
+def bit_not(n, numbits=16):
+    return (1 << numbits) - 1 - n
+
+def signed_to_twos_comp(n, numbits=16):
+    return n if n >= 0 else bit_not(-n, numbits) + 1
+
+@cocotb.test()
+async def test_integration_00(dut):
+
+    clk_256fs = Clock(dut.CLK, 83, units='ns')
+    cocotb.start_soon(clk_256fs.start())
+
+    dut.eurorack_pmod1.ak4619_instance.sdout1.value = 0
+
+    dut.sysmgr_instance.pll_lock.value = 0
+    await RisingEdge(dut.clk_256fs)
+    await RisingEdge(dut.clk_256fs)
+    dut.sysmgr_instance.pll_lock.value = 1
+
+    dut = dut.eurorack_pmod1.ak4619_instance
+
+    N = 20
+
+    await FallingEdge(dut.lrck)
+
+    for i in range(N):
+
+        v = signed_to_twos_comp(int(16000*math.sin((2*math.pi*i)/N)))
+
+        await clock_out_word(dut, v << 16)
+        await clock_out_word(dut, v << 16)
+        await clock_out_word(dut, v << 16)
+        await clock_out_word(dut, v << 16)
+
+        # Note: this edge is also where dac_words <= sample_in (sample.sv)
+
+        print("Data clocked from sdout1 present at sample_outX:")
+        print(hex(dut.sample_out0.value))
+        print(hex(dut.sample_out1.value))
+        print(hex(dut.sample_out2.value))
+        print(hex(dut.sample_out3.value))

--- a/gateware/sim/integration/tb_integration.py
+++ b/gateware/sim/integration/tb_integration.py
@@ -32,6 +32,8 @@ async def test_integration_00(dut):
     cocotb.start_soon(clk_256fs.start())
 
     dut.eurorack_pmod1.ak4619_instance.sdout1.value = 0
+    # Simulate all jacks connected so the cal core doesn't zero them
+    dut.eurorack_pmod1.jack.value = Force(0xFF)
 
     dut.sysmgr_instance.pll_lock.value = 0
     await RisingEdge(dut.clk_256fs)

--- a/gateware/sim/pmod_i2c_master/Makefile
+++ b/gateware/sim/pmod_i2c_master/Makefile
@@ -3,5 +3,6 @@ TOPLEVEL_LANG ?= verilog
 VERILOG_SOURCES = ../../drivers/pmod_i2c_master.sv \
 				  ../../external/no2misc/rtl/i2c_master.v
 MODULE = tb_pmod_i2c_master
+COMPILE_ARGS += -DUNIT_TEST
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/gateware/sim/transpose/tb_transpose.py
+++ b/gateware/sim/transpose/tb_transpose.py
@@ -1,3 +1,4 @@
+import sys
 import pickle
 import cocotb
 import random
@@ -6,20 +7,14 @@ from cocotb.clock import Clock
 from cocotb.triggers import Timer, FallingEdge, RisingEdge, ClockCycles
 from cocotb.handle import Force, Release
 
-def bit_not(n, numbits=16):
-    return (1 << numbits) - 1 - n
-
-def signed_to_twos_comp(n, numbits=16):
-    return n if n >= 0 else bit_not(-n, numbits) + 1
-
-def twos_comp_to_signed(n, numbits=16):
-    if (1 << (numbits-1) & n) > 0:
-        return -int(bit_not(n, numbits) + 1)
-    else:
-        return int(n)
+# Hack to import some helpers despite existing outside a package.
+sys.path.append("..")
+from util.i2s import *
 
 @cocotb.test()
 async def test_transpose_00(dut):
+
+    sample_width = 16
 
     clock = Clock(dut.sample_clk, 5, units='us')
     cocotb.start_soon(clock.start())
@@ -47,8 +42,8 @@ async def test_transpose_00(dut):
 
         data_in = int(1000*math.sin(i / 100))
 
-        dut.sample_in.value = signed_to_twos_comp(data_in)
-        data_out = twos_comp_to_signed(dut.sample_out.value)
+        dut.sample_in.value = bits_from_signed(data_in, sample_width)
+        data_out = signed_from_bits(dut.sample_out.value, sample_width)
 
         print(f"i={i} in:", data_in)
         print(f"i={i} out:", data_out)

--- a/gateware/sim/util/i2s.py
+++ b/gateware/sim/util/i2s.py
@@ -1,0 +1,35 @@
+import math
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import Timer, FallingEdge, RisingEdge, ClockCycles
+from cocotb.handle import Force, Release
+
+async def i2s_clock_out_u32(bick, sdout, word):
+    """Clock out a 32-bit word over I2S."""
+    for i in range(32):
+        await RisingEdge(bick)
+        sdout.value = (word >> (0x1F-i)) & 1
+
+async def i2s_clock_in_u32(bick, sdin):
+    """Clock in a 32-bit word over I2S."""
+    word = 0x00000000
+    await RisingEdge(bick)
+    for i in range(32):
+        await FallingEdge(bick)
+        word |= sdin.value << (0x1F-i)
+    return word
+
+def bits_not(n, width):
+    """Bitwise NOT from positive integer of `width` bits."""
+    return (1 << width) - 1 - n
+
+def bits_from_signed(n, width):
+    """Bits (2s complement) of `width` from signed integer."""
+    return n if n >= 0 else bits_not(-n, width) + 1
+
+def signed_from_bits(n, width):
+    """Signed integer from (2s complement) bits of `width`."""
+    if (1 << (width-1) & n) > 0:
+        return -int(bits_not(n, width) + 1)
+    else:
+        return n

--- a/gateware/top.sv
+++ b/gateware/top.sv
@@ -190,4 +190,13 @@ debug_uart #(
     .jack(jack)
 );
 
+`ifdef COCOTB_SIM
+initial begin
+  $dumpfile ("top.vcd");
+  $dumpvars;
+  #1;
+end
+`endif
+
+
 endmodule


### PR DESCRIPTION
* Add a test which runs the whole top-level icebreaker example with all sub-modules inside it
* Modify `sv` implementations where required to make the simulation more useful
* Clean up and split out some utility functions used by different tests