### PR TITLE
gateware: switch `clk_fs` for `strobe` asserted once per sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This repository contains a bunch of example DSP cores which are continuously bei
 - `gateware/cores/clkdiv.sv` - Clock divider
 - `gateware/cores/sampler.sv` - .wav sampler
 - `gateware/cores/seqswitch.sv` - Sequential routing switch
-- `gateware/cores/stereo_echo.sv` - Echo / decimating delay effect
+- `gateware/cores/digital_echo.sv` - Echo / delay effect
 - `gateware/cores/vca.sv` - VCA (voltage controlled amplifier)
 - `gateware/cores/vco.sv` - VCO (voltage controlled oscillator)
 - `gateware/cores/bitcrush.sv` - Bitcrusher

--- a/gateware/boards/colorlight_i5/sysmgr.v
+++ b/gateware/boards/colorlight_i5/sysmgr.v
@@ -5,7 +5,6 @@ module sysmgr (
 	input  wire clk_in,
 	input  wire rst_in,
 	output wire clk_256fs,
-	output wire clk_fs,
 	output wire rst_out
 );
 
@@ -15,12 +14,10 @@ wire pll_reset;
 wire rst_i;
 
 reg [7:0] rst_cnt;
-reg [7:0] clkdiv;
 
 assign pll_reset = rst_in;
 assign rst_i = ~rst_cnt[7];
 assign rst_out = rst_i;
-assign clk_fs = clkdiv[7];
 
 `ifndef VERILATOR_LINT_ONLY
 
@@ -74,11 +71,5 @@ always @(posedge clk_in)
         rst_cnt <= 8'h0;
     else if (~rst_cnt[7])
         rst_cnt <= rst_cnt + 1;
-
-always @(posedge clk_256fs)
-    if (rst_i)
-        clkdiv <= 8'h00;
-    else
-        clkdiv <= clkdiv + 1;
 
 endmodule // sysmgr

--- a/gateware/boards/ecpix5/sysmgr.v
+++ b/gateware/boards/ecpix5/sysmgr.v
@@ -5,7 +5,6 @@ module sysmgr (
 	input  wire clk_in,
 	input  wire rst_in,
 	output wire clk_256fs,
-	output wire clk_fs,
 	output wire rst_out
 );
 
@@ -15,12 +14,10 @@ wire pll_reset;
 wire rst_i;
 
 reg [7:0] rst_cnt;
-reg [7:0] clkdiv;
 
 assign rst_i = ~rst_cnt[7];
 assign rst_out = rst_i;
 assign pll_reset = rst_in;
-assign clk_fs = clkdiv[7];
 
 `ifndef VERILATOR_LINT_ONLY
 
@@ -70,11 +67,5 @@ always @(posedge clk_in)
         rst_cnt <= 8'h0;
     else if (~rst_cnt[7])
         rst_cnt <= rst_cnt + 1;
-
-always @(posedge clk_256fs)
-    if (rst_i)
-        clkdiv <= 8'h00;
-    else
-        clkdiv <= clkdiv + 1;
 
 endmodule // sysmgr

--- a/gateware/boards/gatemate_evb/sysmgr.v
+++ b/gateware/boards/gatemate_evb/sysmgr.v
@@ -4,7 +4,6 @@ module sysmgr (
 	input  wire clk_in,
 	input  wire rst_in,
 	output wire clk_256fs,
-	output wire clk_fs,
 	output wire rst_out
 );
 
@@ -14,12 +13,10 @@ wire pll_reset;
 wire rst_i;
 
 reg [7:0] rst_cnt;
-reg [7:0] clkdiv;
 
 assign pll_reset = rst_in;
 assign rst_i = ~rst_cnt[7];
 assign rst_out = rst_i;
-assign clk_fs = clkdiv[7];
 
 `ifndef VERILATOR_LINT_ONLY
 
@@ -45,11 +42,5 @@ always @(posedge clk_in)
         rst_cnt <= 8'h0;
     else if (~rst_cnt[7])
         rst_cnt <= rst_cnt + 1;
-
-always @(posedge clk_256fs)
-    if (rst_i)
-        clkdiv <= 8'h00;
-    else
-        clkdiv <= clkdiv + 1;
 
 endmodule // sysmgr

--- a/gateware/boards/icebreaker/sysmgr.v
+++ b/gateware/boards/icebreaker/sysmgr.v
@@ -8,7 +8,6 @@ module sysmgr (
     // but we leave all this PLL logic here as you might need to scale
     // the clock down to 12m on different boards.
 	output wire clk_256fs,
-	output wire clk_fs,
 	output wire rst_out
 );
 
@@ -22,12 +21,10 @@ module sysmgr (
 	wire rst_i;
 
 	reg [7:0] rst_cnt;
-	reg [7:0] clkdiv;
 
 	assign clk_256fs = clk_1x_i;
 	assign pll_reset_n = ~rst_in;
 	assign rst_i = rst_cnt[7];
-	assign clk_fs = clkdiv[7];
 
 	// PLL instance
 `ifndef COCOTB_SIM
@@ -68,13 +65,6 @@ module sysmgr (
 			rst_cnt <= 8'h80;
 		else if (rst_cnt[7])
 			rst_cnt <= rst_cnt + 1;
-
-    always @(posedge clk_256fs)
-        if (rst_i)
-            clkdiv <= 8'h00;
-        else
-            clkdiv <= clkdiv + 1;
-
 
 `ifndef COCOTB_SIM
 `ifndef VERILATOR_LINT_ONLY

--- a/gateware/boards/pico_ice/sysmgr.v
+++ b/gateware/boards/pico_ice/sysmgr.v
@@ -3,7 +3,6 @@
 module sysmgr (
 	input  wire rst_in,
 	output wire clk_256fs,
-	output wire clk_fs,
 	output wire rst_out
 );
 
@@ -11,10 +10,8 @@ module sysmgr (
 	wire rst_i;
 
 	reg [7:0] rst_cnt = 8'h80;
-    reg [7:0] clkdiv;
 
     assign clk_256fs = clk_12m;
-    assign clk_fs = clkdiv[7];
 	assign rst_i = rst_cnt[7];
 
 `ifndef VERILATOR_LINT_ONLY
@@ -34,12 +31,6 @@ module sysmgr (
 			rst_cnt <= 8'h80;
 		else if (rst_cnt[7])
 			rst_cnt <= rst_cnt + 1;
-
-    always @(posedge clk_256fs)
-        if (rst_i)
-            clkdiv <= 8'h00;
-        else
-            clkdiv <= clkdiv + 1;
 
 `ifndef VERILATOR_LINT_ONLY
 	SB_GB rst_gbuf_I (

--- a/gateware/cal/cal.sv
+++ b/gateware/cal/cal.sv
@@ -26,7 +26,7 @@ module cal #(
 )(
     input rst,
     input clk_256fs,
-    input clk_fs,
+    input strobe,
     input [7:0] jack,
     input signed [W-1:0] in0,
     input signed [W-1:0] in1,
@@ -64,7 +64,6 @@ logic signed [W-1:0]     cal_mem [0:(2*N_CHANNELS)-1];
 logic signed [(2*W)-1:0] out     [N_CHANNELS];
 logic        [2:0]       ch;
 logic        [2:0]       state;
-logic                    l_clk_fs;
 
 // Calibration memory for 8 channels stored as
 // 2 bytes shift, 2 bytes multiply * 8 channels.
@@ -73,7 +72,6 @@ initial $readmemh(CAL_MEM_FILE, cal_mem);
 always_ff @(posedge clk_256fs) begin
 
     if (rst) begin
-        l_clk_fs <= 0;
         ch <= 0;
         state <= CAL_ST_LATCH;
         out[0] <= 0;
@@ -86,10 +84,7 @@ always_ff @(posedge clk_256fs) begin
         out[7] <= 0;
     end else begin
 
-        l_clk_fs <= clk_fs;
-
-        // On rising clk_fs.
-        if (clk_fs && (l_clk_fs != clk_fs)) begin
+        if (strobe) begin
             state <= CAL_ST_LATCH;
             ch <= 0;
         end else begin

--- a/gateware/cal/cal_mem_default_r31.hex
+++ b/gateware/cal/cal_mem_default_r31.hex
@@ -1,4 +1,4 @@
 // Input calibration constants
-@00000000 0 400 0 400 0 400 0 400
+@00000000 11c0 650 10b2 64f 114a 650 1134 64f
 // Output calibration constants
-@00000008 0 400 0 400 0 400 0 400
+@00000008 f6e 3ed e53 3ef f3d 3ee fa0 3ef

--- a/gateware/cal/cal_mem_default_r31.hex
+++ b/gateware/cal/cal_mem_default_r31.hex
@@ -1,4 +1,4 @@
 // Input calibration constants
-@00000000 11c0 650 10b2 64f 114a 650 1134 64f
+@00000000 0 400 0 400 0 400 0 400
 // Output calibration constants
-@00000008 f6e 3ed e53 3ef f3d 3ee fa0 3ef
+@00000008 0 400 0 400 0 400 0 400

--- a/gateware/cores/bitcrush.sv
+++ b/gateware/cores/bitcrush.sv
@@ -27,6 +27,7 @@ module bitcrush #(
 );
 
 logic signed [W-1:0] mask;
+logic signed [W-1:0] out0;
 logic signed [W-1:0] out1;
 logic signed [W-1:0] out2;
 logic signed [W-1:0] out3;
@@ -45,13 +46,14 @@ assign mask = (sample_in0 > 4*5000) ? 16'b1111111111111111 :
 
 always_ff @(posedge clk) begin
     if (strobe) begin
+        out0 <= sample_in0;
         out1 <= sample_in1 & mask;
         out2 <= sample_in2 & mask;
         out3 <= sample_in3 & mask;
     end
 end
 
-assign sample_out0 = sample_in0;
+assign sample_out0 = out0;
 assign sample_out1 = out1;
 assign sample_out2 = out2;
 assign sample_out3 = out3;

--- a/gateware/cores/bitcrush.sv
+++ b/gateware/cores/bitcrush.sv
@@ -14,7 +14,7 @@ module bitcrush #(
 )(
     input rst,
     input clk,
-    input sample_clk,
+    input strobe,
     input signed [W-1:0] sample_in0,
     input signed [W-1:0] sample_in1,
     input signed [W-1:0] sample_in2,
@@ -43,10 +43,12 @@ assign mask = (sample_in0 > 4*5000) ? 16'b1111111111111111 :
               (sample_in0 > 4* 500) ? 16'b1110000000000000 :
                                       16'b1100000000000000;
 
-always_ff @(posedge sample_clk) begin
-    out1 <= sample_in1 & mask;
-    out2 <= sample_in2 & mask;
-    out3 <= sample_in3 & mask;
+always_ff @(posedge clk) begin
+    if (strobe) begin
+        out1 <= sample_in1 & mask;
+        out2 <= sample_in2 & mask;
+        out3 <= sample_in3 & mask;
+    end
 end
 
 assign sample_out0 = sample_in0;

--- a/gateware/cores/clkdiv.sv
+++ b/gateware/cores/clkdiv.sv
@@ -19,7 +19,7 @@ module clkdiv #(
 )(
     input rst,
     input clk,
-    input sample_clk,
+    input strobe,
     input signed [W-1:0] sample_in0,
     input signed [W-1:0] sample_in1,
     input signed [W-1:0] sample_in2,
@@ -46,13 +46,15 @@ localparam OUT_LO     = `FROM_MV(0);
 logic last_state_hi = 1'b0;
 logic [3:0] div = 0;
 
-always_ff @(posedge sample_clk) begin
-    if (sample_in0 > SCHMITT_HI && !last_state_hi) begin
-        last_state_hi <= 1'b1;
-        // Increment count on every rising edge.
-        div <= div + 1;
-    end else if (sample_in0 < SCHMITT_LO && last_state_hi) begin
-        last_state_hi <= 1'b0;
+always_ff @(posedge clk) begin
+    if (strobe) begin
+        if (sample_in0 > SCHMITT_HI && !last_state_hi) begin
+            last_state_hi <= 1'b1;
+            // Increment count on every rising edge.
+            div <= div + 1;
+        end else if (sample_in0 < SCHMITT_LO && last_state_hi) begin
+            last_state_hi <= 1'b0;
+        end
     end
 end
 

--- a/gateware/cores/digital_echo.sv
+++ b/gateware/cores/digital_echo.sv
@@ -10,7 +10,7 @@
 module digital_echo #(
     parameter W = 16,
     // Length of the echo buffers in samples.
-    parameter ECHO_LEN = 4096,
+    parameter ECHO_LEN = 4096
 )(
     input rst,
     input clk,

--- a/gateware/cores/digital_echo.sv
+++ b/gateware/cores/digital_echo.sv
@@ -1,27 +1,20 @@
-// Dual digital echo effect.
+// Digital echo effect.
 //
 // Given input audio on input 0 / 1, apply a digital echo effect.
 //
 // Mapping:
 // - Input 0: Audio input 0
-// - Input 1: Audio input 1
 // - Output 0: Audio input 0 (mirrored)
 // - Output 1: Audio input 0 (echo)
-// - Output 2: Audio input 1 (mirrored)
-// - Output 3: Audio input 1 (echo)
 
-module stereo_echo #(
+module digital_echo #(
     parameter W = 16,
     // Length of the echo buffers in samples.
-    parameter ECHO_LEN = 2048,
-    // Decimate samples - this allows you to get long echo times
-    // without using all the BRAM. Effectively you end up with:
-    // ECHO_LEN (effective) = ECHO_LEN * (2 << DECIMATE)
-    parameter DECIMATE = 2
+    parameter ECHO_LEN = 4096,
 )(
     input rst,
     input clk,
-    input sample_clk,
+    input strobe,
     input signed [W-1:0] sample_in0,
     input signed [W-1:0] sample_in1,
     input signed [W-1:0] sample_in2,
@@ -33,26 +26,13 @@ module stereo_echo #(
     input [7:0] jack
 );
 
-logic [15:0] decimate = 0;
-logic decimate_clk = decimate[DECIMATE];
-
-always_ff @(posedge sample_clk) begin
-    decimate <= decimate + 1;
-end
-
 echo #(W, ECHO_LEN) echo0(
-    .sample_clk(decimate_clk),
+    .clk(clk),
+    .strobe(strobe),
     .sample_in(sample_in0),
     .sample_out(sample_out1)
 );
 
-echo #(W, ECHO_LEN) echo1(
-    .sample_clk(decimate_clk),
-    .sample_in(sample_in1),
-    .sample_out(sample_out3)
-);
-
 assign sample_out0 = sample_in0;
-assign sample_out2 = sample_in1;
 
 endmodule

--- a/gateware/cores/filter.sv
+++ b/gateware/cores/filter.sv
@@ -13,7 +13,7 @@ module filter #(
 )(
     input rst,
     input clk,
-    input sample_clk,
+    input strobe,
     input signed [W-1:0] sample_in0,
     input signed [W-1:0] sample_in1,
     input signed [W-1:0] sample_in2,
@@ -28,7 +28,7 @@ module filter #(
 karlsen_lpf_pipelined #(.W(W)) lpf_inst(
     .rst(rst),
     .clk(clk),
-    .sample_clk(sample_clk),
+    .strobe(strobe),
     .sample_in(sample_in0),
     .sample_out(sample_out0),
     .g(sample_in1),

--- a/gateware/cores/mirror.sv
+++ b/gateware/cores/mirror.sv
@@ -9,7 +9,7 @@ module mirror #(
 )(
     input rst,
     input clk,
-    input sample_clk,
+    input strobe,
     input signed [W-1:0] sample_in0,
     input signed [W-1:0] sample_in1,
     input signed [W-1:0] sample_in2,

--- a/gateware/cores/pitch_shift.sv
+++ b/gateware/cores/pitch_shift.sv
@@ -14,7 +14,7 @@ module pitch_shift #(
 )(
     input rst,
     input clk,
-    input sample_clk,
+    input strobe,
     input signed [W-1:0] sample_in0,
     input signed [W-1:0] sample_in1,
     input signed [W-1:0] sample_in2,
@@ -29,7 +29,8 @@ module pitch_shift #(
 transpose #(
     .W(W)
 ) transpose_instance (
-    .sample_clk(sample_clk),
+    .clk,
+    .strobe,
     .pitch(sample_in1),
     .sample_in(sample_in0),
     .sample_out(sample_out1)

--- a/gateware/cores/touch_cv.sv
+++ b/gateware/cores/touch_cv.sv
@@ -15,7 +15,7 @@ module touch_cv #(
 )(
     input rst,
     input clk,
-    input sample_clk,
+    input strobe,
     input signed [W-1:0] sample_in0,
     input signed [W-1:0] sample_in1,
     input signed [W-1:0] sample_in2,

--- a/gateware/cores/util/delayline.sv
+++ b/gateware/cores/util/delayline.sv
@@ -6,7 +6,8 @@ module delayline #(
     parameter W = 16,
     parameter MAX_DELAY = 1024
 )(
-    input sample_clk,
+    input clk,
+    input strobe,
     input [$clog2(MAX_DELAY)-1:0] delay,
     input signed [W-1:0] in,
     output logic signed [W-1:0] out
@@ -17,13 +18,15 @@ logic [$clog2(MAX_DELAY)-1:0] waddr = 0;
 
 logic signed [W-1:0] bram[MAX_DELAY];
 
-always_ff @(posedge sample_clk) begin
-    waddr <= waddr + 1;
-    // This subtraction wraps correctly as long as MAX_DELAY is
-    // a power of 2.
-    raddr <= waddr - delay;
-    bram[waddr] <= in;
-    out <= bram[raddr];
+always_ff @(posedge clk) begin
+    if (strobe) begin
+        waddr <= waddr + 1;
+        // This subtraction wraps correctly as long as MAX_DELAY is
+        // a power of 2.
+        raddr <= waddr - delay;
+        bram[waddr] <= in;
+        out <= bram[raddr];
+    end
 end
 
 endmodule

--- a/gateware/cores/util/echo.sv
+++ b/gateware/cores/util/echo.sv
@@ -4,7 +4,8 @@ module echo #(
     parameter W = 16,
     parameter ECHO_MAX_SAMPLES = 1024
 )(
-    input sample_clk,
+    input clk,
+    input strobe,
     input signed [W-1:0] sample_in,
     output logic signed [W-1:0] sample_out
 );
@@ -18,15 +19,18 @@ logic signed [W-1:0] delay_in;
 logic signed [W-1:0] delay_out;
 
 delayline #(W, ECHO_MAX_SAMPLES) delay_0 (
-    .sample_clk(sample_clk),
+    .clk(clk),
+    .strobe(strobe),
     .delay(DELAY),
     .in(delay_in),
     .out(delay_out)
 );
 
-always_ff @(posedge sample_clk) begin
-    delay_in <= (sample_in >>> 1) + (delay_out >>> FEEDBACK_SHIFT);
-    sample_out <= delay_out;
+always_ff @(posedge clk) begin
+    if (strobe) begin
+        delay_in <= (sample_in >>> 1) + (delay_out >>> FEEDBACK_SHIFT);
+        sample_out <= delay_out;
+    end
 end
 
 endmodule

--- a/gateware/cores/util/filter/karlsen_lpf_pipelined.sv
+++ b/gateware/cores/util/filter/karlsen_lpf_pipelined.sv
@@ -33,7 +33,7 @@ module karlsen_lpf_pipelined #(
 )(
     input rst,
     input clk,
-    input sample_clk,
+    input strobe,
     // See header comment for what these parameters mean.
     input signed [W-1:0] g,
     input signed [W-1:0] resonance,
@@ -49,7 +49,6 @@ localparam WMULT = 18; // Width of multiplier input
 localparam signed [WMULT-1:0] MAX = (2**(W-1))-1;
 localparam signed [WMULT-1:0] MIN = -(2**(W-1));
 
-logic prev_sample_clk;
 logic [3:0] state;
 
 logic signed [WMULT-1:0] in_ex;
@@ -72,7 +71,6 @@ assign resonance_ex = `CLAMP_POSITIVE(resonance) <<< 2;
 smul_shift_18x18 multiplier(.a(smul_a), .b(smul_b), .scale(smul_scale), .o(smul_out));
 
 always_ff @(posedge clk) begin
-    prev_sample_clk <= sample_clk;
     if (rst) begin
         state <= 0;
         a1 <= 0;
@@ -80,9 +78,8 @@ always_ff @(posedge clk) begin
         a3 <= 0;
         a4 <= 0;
         sample_out <= 0;
-        prev_sample_clk <= 0;
     end else begin
-        if (sample_clk != prev_sample_clk) begin
+        if (strobe) begin
             state <= 0;
         end else begin
             if (state < 8)

--- a/gateware/cores/util/wavetable_osc.sv
+++ b/gateware/cores/util/wavetable_osc.sv
@@ -5,7 +5,8 @@ module wavetable_osc #(
     parameter WAVETABLE_SIZE = 256
 )(
     input rst,
-    input sample_clk,
+    input clk,
+    input strobe,
     input [31:0] wavetable_inc,
     output logic signed [W-1:0] out
 );
@@ -16,13 +17,15 @@ initial $readmemh(WAVETABLE_PATH, wavetable);
 // Position in wavetable - N.F fixed-point where BIT_START is size of F.
 logic [31:0] wavetable_pos = 0;
 
-always_ff @(posedge sample_clk) begin
-    if (rst) begin
-        wavetable_pos <= 0;
-    end else begin
-        wavetable_pos <= wavetable_pos + wavetable_inc;
-        // Take top N bits of wavetable_pos as output.
-        out <= wavetable[wavetable_pos[FRAC_BITS+$clog2(WAVETABLE_SIZE)-1:FRAC_BITS]];
+always_ff @(posedge clk) begin
+    if (strobe) begin
+        if (rst) begin
+            wavetable_pos <= 0;
+        end else begin
+            wavetable_pos <= wavetable_pos + wavetable_inc;
+            // Take top N bits of wavetable_pos as output.
+            out <= wavetable[wavetable_pos[FRAC_BITS+$clog2(WAVETABLE_SIZE)-1:FRAC_BITS]];
+        end
     end
 end
 

--- a/gateware/cores/vca.sv
+++ b/gateware/cores/vca.sv
@@ -19,7 +19,7 @@ module vca #(
 )(
     input rst,
     input clk,
-    input sample_clk,
+    input strobe,
     input signed [W-1:0] sample_in0,
     input signed [W-1:0] sample_in1,
     input signed [W-1:0] sample_in2,

--- a/gateware/drivers/ak4619.sv
+++ b/gateware/drivers/ak4619.sv
@@ -71,18 +71,19 @@ assign bit_counter = clkdiv[5:1];
 
 always_ff @(posedge clk_256fs) begin
     if (rst) begin
+        sdin1 <= 0;
         clkdiv <= 0;
-        dac_words = 0;
-        sample_out0 <= 0;
-        sample_out1 <= 0;
-        sample_out2 <= 0;
-        sample_out3 <= 0;
+        adc_words[0] <= 0;
+        adc_words[1] <= 0;
+        adc_words[2] <= 0;
+        adc_words[3] <= 0;
+        dac_words <= 0;
     end else if (strobe) begin
         // Synchronize clkdiv to the incoming sample strobe, latching
         // our inputs and outputs in the clock cycle that `strobe` is high.
         clkdiv <= 8'h0;
-        dac_words = {sample_in3, sample_in2,
-                     sample_in1, sample_in0};
+        dac_words <= {sample_in3, sample_in2,
+                      sample_in1, sample_in0};
         sample_out0  <= adc_words[0];
         sample_out1  <= adc_words[1];
         sample_out2  <= adc_words[2];

--- a/gateware/eurorack_pmod.sv
+++ b/gateware/eurorack_pmod.sv
@@ -13,7 +13,7 @@ module eurorack_pmod #(
     parameter LED_CFG_FILE  = "drivers/pca9635-cfg.hex"
 )(
     input clk_256fs,
-    input clk_fs,
+    input strobe,
     input rst,
 
     // Signals to/from eurorack-pmod hardware.
@@ -98,7 +98,7 @@ cal #(
 ) cal_instance (
     .rst(rst),
     .clk_256fs (clk_256fs),
-    .clk_fs (clk_fs),
+    .strobe (strobe),
     // Calibrated inputs are zeroed if jack is unplugged.
     .jack (jack),
     // Note: inputs samples are inverted by analog frontend
@@ -127,7 +127,7 @@ ak4619 #(
 ) ak4619_instance (
     .rst       (rst),
     .clk_256fs (clk_256fs),
-    .clk_fs    (clk_fs),
+    .strobe    (strobe),
 
     .pdn       (pdn),
     .mclk      (mclk),

--- a/gateware/mk/common.mk
+++ b/gateware/mk/common.mk
@@ -13,7 +13,7 @@ SRC_COMMON = eurorack_pmod.sv \
 		     cores/vca.sv \
 		     cores/vco.sv \
 		     cores/pitch_shift.sv \
-		     cores/stereo_echo.sv \
+		     cores/digital_echo.sv \
 		     cores/filter.sv \
 		     cores/touch_cv.sv \
 		     cores/util/filter/karlsen_lpf_pipelined.sv \

--- a/gateware/scripts/verilator_lint.sh
+++ b/gateware/scripts/verilator_lint.sh
@@ -56,6 +56,6 @@ verilator --lint-only cores/util/filter/karlsen_lpf.sv
 verilator --lint-only cores/util/filter/karlsen_lpf_pipelined.sv
 verilator --lint-only -Icores -Icores/util/filter filter.sv
 verilator --lint-only -Icores -Icores/util pitch_shift.sv
-verilator --lint-only -Icores -Icores/util stereo_echo.sv
+verilator --lint-only -Icores -Icores/util digital_echo.sv
 verilator --lint-only -Icores -Icores/util dc_block.sv
 verilator --lint-only -Icores -Icores/util wavetable_osc.sv

--- a/gateware/sim/integration/tb_integration.py
+++ b/gateware/sim/integration/tb_integration.py
@@ -29,13 +29,16 @@ async def test_integration_00(dut):
     await RisingEdge(dut.clk_256fs)
     dut.sysmgr_instance.pll_lock.value = 1
 
+    await FallingEdge(dut.strobe)
+    await FallingEdge(dut.strobe)
+
     ak4619 = dut.eurorack_pmod1.ak4619_instance
 
     N = 20
 
     for i in range(N):
 
-        v = bits_from_signed(int(16000*math.sin((2*math.pi*i)/N)), sample_width)
+        v = bits_from_signed(0x00FF, sample_width)#int(16000*math.sin((2*math.pi*i)/N)), sample_width)
 
         await FallingEdge(ak4619.lrck)
 

--- a/gateware/sim/integration/tb_integration.py
+++ b/gateware/sim/integration/tb_integration.py
@@ -29,18 +29,15 @@ async def test_integration_00(dut):
     await RisingEdge(dut.clk_256fs)
     dut.sysmgr_instance.pll_lock.value = 1
 
-    await FallingEdge(dut.strobe)
-    await FallingEdge(dut.strobe)
-
     ak4619 = dut.eurorack_pmod1.ak4619_instance
+
+    await FallingEdge(dut.strobe)
 
     N = 20
 
     for i in range(N):
 
-        v = bits_from_signed(0x00FF, sample_width)#int(16000*math.sin((2*math.pi*i)/N)), sample_width)
-
-        await FallingEdge(ak4619.lrck)
+        v = bits_from_signed(int(16000*math.sin((2*math.pi*i)/N)), sample_width)
 
         await i2s_clock_out_u32(ak4619.bick, ak4619.sdout1, v << 16)
         await i2s_clock_out_u32(ak4619.bick, ak4619.sdout1, v << 16)

--- a/gateware/top.sv
+++ b/gateware/top.sv
@@ -34,7 +34,7 @@ logic [7:0] strobe_clkdiv;
 
 always_ff @(posedge clk_256fs) begin
     if (rst) begin
-        strobe_clkdiv = 8'h0;
+        strobe_clkdiv <= 8'h0;
     end else begin
         strobe_clkdiv <= strobe_clkdiv + 1;
     end

--- a/gateware/top.sv
+++ b/gateware/top.sv
@@ -29,7 +29,17 @@ module top #(
 
 logic rst;
 logic clk_256fs;
-logic clk_fs; // FIXME: assign from PLL divider?
+logic strobe;
+logic [7:0] strobe_clkdiv;
+
+always_ff @(posedge clk_256fs) begin
+    if (rst) begin
+        strobe_clkdiv = 8'h0;
+    end else begin
+        strobe_clkdiv <= strobe_clkdiv + 1;
+    end
+    strobe <= (strobe_clkdiv == 8'h0);
+end
 
 // Button signal is used for resets, unless we are input calibration
 // mode in which case it is used for setting the output cal values.
@@ -90,7 +100,6 @@ sysmgr sysmgr_instance (
     .rst_in(1'b0),
 `endif
     .clk_256fs(clk_256fs),
-    .clk_fs(clk_fs),
     .rst_out(rst)
 );
 
@@ -101,7 +110,7 @@ sysmgr sysmgr_instance (
 ) dsp_core_instance (
       .rst         (rst)
     , .clk         (clk_256fs)
-    , .sample_clk  (clk_fs)
+    , .strobe      (strobe)
     , .sample_in0  (in0)
     , .sample_in1  (in1)
     , .sample_in2  (in2)
@@ -151,7 +160,7 @@ eurorack_pmod #(
     .W(W)
 ) eurorack_pmod1 (
     .clk_256fs(clk_256fs),
-    .clk_fs   (clk_fs),
+    .strobe   (strobe),
     .rst(rst),
 
     .i2c_scl_oe(i2c_scl_oe),


### PR DESCRIPTION
Instead of dividing clk_256fs by 256 to create `clk_fs`, switch to a `strobe` signal that is high once per sample. This makes it more obvious that the whole repository works in 1 clock domain. Tested all example DSP cores on ecpix5 and icebreaker.