### PR TITLE
Makefile and pin definitions for Icesugar

### DIFF
--- a/gateware/boards/icesugar/Makefile
+++ b/gateware/boards/icesugar/Makefile
@@ -1,0 +1,29 @@
+PROJ = top
+
+DEVICE = up5k
+PACKAGE = sg48
+PIN_DEF = ./boards/icesugar/pinmap.pcf
+# UART: 1Mbaud
+ADD_DEFINES = -DSELECTED_DSP_CORE=$(CORE) -DINVERT_BUTTON=1 -DDEBUG_UART_CLKDIV=12
+
+# IceSugar devices load firmware via an exposed USB Mass Storage device.
+# Assume the OS has mounted it here.
+ICELINK_DIRECTORY=/media/$(USER)/iCELink
+
+include ./mk/common.mk
+include ./mk/ice40.mk
+
+ADD_SRC = boards/icebreaker/sysmgr.v \
+		  $(SRC_COMMON)
+
+prog: $(BUILD)/$(PROJ).bin
+	@if [ ! -d $(ICELINK_DIRECTORY) ] ; then \
+		echo "Can't find iCELink storage device" 1>&2 ; \
+		exit 1 ; \
+	fi ; \
+	if ! cp $(BUILD)/$(PROJ).bin $(ICELINK_DIRECTORY) ; then \
+		echo "failed to install bitstream" 1>&2 ; \
+		exit 1 ; \
+	fi ; \
+	echo "Bitstream installed to $(ICELINK_DIRECTORY)" 1>&2
+

--- a/gateware/boards/icesugar/pinmap.pcf
+++ b/gateware/boards/icesugar/pinmap.pcf
@@ -1,0 +1,24 @@
+# 12 MHz clock
+set_io -nowarn	CLK		35
+set_frequency	CLK		12
+
+# UART should be attached though the iCELink STM32 processor, showing up
+# as /dev/ttyACM* on Linux. Otherwise it's on PMOD1 pin 2.
+set_io -nowarn	UART_TX		6
+
+# There's no momentary button hooked up to a pin on the IceSugar (the one
+# tactile switch drops SPI_VCCIO1 as a hard reset), so hook the soft reset
+# signal up to one of the onboard switches (S1/1, active low). It's not
+# useful, but it satisfies the design.
+set_io -nowarn	RESET_BUTTON	18
+
+# PMOD 2, assuming horizontal flip (ribbon cable between eurorack-pmod
+# and PMOD connector IS in place).
+set_io -nowarn	PMOD_SDIN1	46	# P2_1
+set_io -nowarn	PMOD_SDOUT1	44	# P2_2
+set_io -nowarn	PMOD_LRCK	42	# P2_3
+set_io -nowarn	PMOD_BICK	37	# P2_4
+set_io -nowarn	PMOD_MCLK	36	# P2_9
+set_io -nowarn	PMOD_PDN	38	# P2_10
+set_io -nowarn	PMOD_I2C_SDA	43	# P2_11
+set_io -nowarn	PMOD_I2C_SCL	45	# P2_12


### PR DESCRIPTION
Icesugar is another cheap iCE40UP5K-SG48 board like Icebreaker, but with a slightly different pinout. It also loads bitstreams via a USB mass-storage interface rather than using iceprog.

https://github.com/wuxx/icesugar has more details on the board.